### PR TITLE
docs: add legal policy documents

### DIFF
--- a/POLITICA_DE_PRIVACIDAD.md
+++ b/POLITICA_DE_PRIVACIDAD.md
@@ -1,0 +1,27 @@
+# Política de Privacidad
+
+Última actualización: 17 de mayo de 2024
+
+Esta política describe cómo se maneja la información dentro de la aplicación web.
+
+## Datos que se recopilan
+
+- La aplicación no recolecta información personal ni envía datos a servidores externos.
+- Los estados de lectura, idioma y preferencias se almacenan localmente en tu navegador mediante **LocalStorage**.
+
+## Uso de la información
+
+- Los datos guardados se utilizan únicamente para recordar tus preferencias y progreso de lectura.
+- Puedes eliminar esta información limpiando el almacenamiento del navegador o usando las opciones de reinicio del sitio.
+
+## Servicios de terceros
+
+- La aplicación no utiliza cookies de terceros, analíticas ni publicidad.
+- Los enlaces externos presentes en el sitio son responsabilidad de sus respectivos propietarios.
+
+## Cambios en esta política
+
+Podemos actualizar esta política en el futuro. Las modificaciones serán publicadas en este repositorio.
+
+Si tienes dudas sobre esta política, puedes abrir un issue en el repositorio.
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cosmere - Guía de Lectura Interactiva
 
+[📄 Términos y Condiciones](TERMINOS_Y_CONDICIONES.md) | [🔐 Política de Privacidad](POLITICA_DE_PRIVACIDAD.md)
+
 Una aplicación web interactiva para organizar y hacer seguimiento de la lectura de los libros del Cosmere de Brandon Sanderson.
 
 ## 📚 Descripción

--- a/TERMINOS_Y_CONDICIONES.md
+++ b/TERMINOS_Y_CONDICIONES.md
@@ -1,0 +1,29 @@
+# Términos y Condiciones
+
+Última actualización: 17 de mayo de 2024
+
+Al acceder y utilizar esta aplicación web, aceptas los siguientes términos y condiciones. Si no estás de acuerdo con alguna parte, por favor no utilices el sitio.
+
+## Uso del sitio
+
+- La aplicación se proporciona exclusivamente para uso personal y sin fines comerciales.
+- La organización de libros y el seguimiento de lectura se guardan únicamente en tu navegador mediante **LocalStorage**.
+- Eres responsable de mantener la confidencialidad y respaldo de los datos almacenados en tu dispositivo.
+
+## Propiedad intelectual
+
+- Esta aplicación no es oficial y no está afiliada a Brandon Sanderson ni a sus editoriales.
+- Todos los derechos sobre los libros y personajes pertenecen a sus respectivos propietarios.
+- El código fuente de la aplicación se distribuye bajo licencia MIT.
+
+## Limitación de responsabilidad
+
+- El desarrollador no garantiza la disponibilidad continua del sitio ni la ausencia de errores.
+- El uso de la aplicación es bajo tu propio riesgo. No nos hacemos responsables por pérdidas o daños derivados de su uso.
+
+## Modificaciones
+
+Nos reservamos el derecho de modificar estos términos en cualquier momento. Las modificaciones entrarán en vigor al publicarse en este repositorio.
+
+Para más información sobre el manejo de datos, consulta nuestra [Política de Privacidad](POLITICA_DE_PRIVACIDAD.md).
+


### PR DESCRIPTION
## Summary
- link legal policies in README
- add standalone terms and conditions
- document privacy practices for local data storage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7de8fc59c8331b36dff8d6c890c00