### PR TITLE
Add Ko-fi support button and update documentation

### DIFF
--- a/POLITICA_DE_PRIVACIDAD.md
+++ b/POLITICA_DE_PRIVACIDAD.md
@@ -18,6 +18,7 @@ Esta política describe cómo se maneja la información dentro de la aplicación
 
 - La aplicación no utiliza cookies de terceros, analíticas ni publicidad.
 - Los enlaces externos presentes en el sitio son responsabilidad de sus respectivos propietarios.
+- Se incluye un enlace a [Ko-fi](https://ko-fi.com/) para recibir contribuciones voluntarias; si decidís utilizarlo, se aplicarán las políticas de privacidad de Ko-fi.
 
 ## Cambios en esta política
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ La aplicación incluye todos los libros principales del Cosmere hasta 2024:
 - Preferencias de idioma y filtros se mantienen entre sesiones
 - Datos almacenados localmente en el navegador
 
+## ☕ Apoyá el proyecto
+
+Si disfrutás de esta guía y querés colaborar, podés invitarme un café a través de Ko-fi mediante el botón fijo que verás en la aplicación o visitando [https://ko-fi.com/A0A81LDMP2](https://ko-fi.com/A0A81LDMP2). Las contribuciones son completamente opcionales y ayudan a mantener y mejorar el proyecto.
+
 ## 🛠️ Tecnologías
 
 - **HTML5** - Estructura semántica

--- a/TERMINOS_Y_CONDICIONES.md
+++ b/TERMINOS_Y_CONDICIONES.md
@@ -21,6 +21,12 @@ Al acceder y utilizar esta aplicación web, aceptás los siguientes términos y 
 - El desarrollador no garantiza la disponibilidad continua del sitio ni la ausencia de errores.
 - El uso de la aplicación es bajo tu propio riesgo. No nos hacemos responsables por pérdidas o daños derivados de su uso.
 
+## Apoyo voluntario
+
+- El sitio incluye un enlace externo a Ko-fi para permitir contribuciones opcionales.
+- Todas las colaboraciones económicas son voluntarias y no condicionan el acceso a las funcionalidades de la aplicación.
+- Al seguir el enlace de Ko-fi serás redirigido a un servicio de terceros con sus propias condiciones y políticas.
+
 ## Modificaciones
 
 Nos reservamos el derecho de modificar estos términos en cualquier momento. Las modificaciones entrarán en vigor al publicarse en este repositorio.

--- a/index.html
+++ b/index.html
@@ -12,6 +12,55 @@
       background-color: #fafafa;
     }
 
+    .kofi-support {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      z-index: 1000;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+      padding: 10px 12px;
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.95);
+      box-shadow: 0 8px 24px rgba(31, 41, 55, 0.12);
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .kofi-support:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 12px 32px rgba(31, 41, 55, 0.16);
+    }
+
+    .kofi-support a img {
+      display: block;
+      height: 36px;
+      border: 0;
+    }
+
+    .kofi-support span {
+      font-size: 0.85rem;
+      color: #1f2937;
+      font-weight: 600;
+      text-align: center;
+      line-height: 1.3;
+    }
+
+    @media (max-width: 720px) {
+      .kofi-support {
+        top: auto;
+        bottom: 20px;
+        right: 20px;
+        padding: 10px;
+      }
+
+      .kofi-support span {
+        font-size: 0.9rem;
+      }
+    }
+
     h1 {
       text-align: center;
       margin-top: 20px;
@@ -141,6 +190,12 @@
   </style>
 </head>
 <body>
+  <div class="kofi-support" aria-live="polite">
+    <a id="kofiButton" href="https://ko-fi.com/A0A81LDMP2" target="_blank" rel="noopener noreferrer">
+      <img id="kofiImage" src="https://storage.ko-fi.com/cdn/kofi6.png?v=6" alt="Apoyá el proyecto en Ko-fi">
+    </a>
+    <span id="kofiText">Apoyá el proyecto en Ko-fi</span>
+  </div>
   <h1 id="tituloPrincipal">Libros de Brandon Sanderson</h1>
 
   <!-- Controles -->
@@ -231,7 +286,10 @@
         avisoLegal: "⚠️ Aviso Legal: NO soy el autor de los libros de Brandon Sanderson. Todos los derechos sobre los libros pertenecen a Brandon Sanderson y sus editores. Solo tengo derechos sobre el código de esta aplicación web.",
         linkReadme: "📖 Ver README completo",
         marcaRegistrada: "Cosmere es una marca registrada de Brandon Sanderson",
-        saltoA: "→ Salto a"
+        saltoA: "→ Salto a",
+        kofiText: "Apoyá el proyecto en Ko-fi",
+        kofiAriaLabel: "Apoyá el proyecto invitándome un café en Ko-fi",
+        kofiAlt: "Botón para invitarme un café en Ko-fi"
       },
       en: {
         titulo: "Brandon Sanderson's Books",
@@ -242,7 +300,10 @@
         avisoLegal: "⚠️ Legal Notice: I am NOT the author of Brandon Sanderson's books. All rights to the books belong to Brandon Sanderson and his publishers. I only have rights to the code of this web application.",
         linkReadme: "📖 View full README",
         marcaRegistrada: "Cosmere is a registered trademark of Brandon Sanderson",
-        saltoA: "→ Jump to"
+        saltoA: "→ Jump to",
+        kofiText: "Support the project on Ko-fi",
+        kofiAriaLabel: "Support the project by buying me a coffee on Ko-fi",
+        kofiAlt: "Button to buy me a coffee on Ko-fi"
       }
     };
     
@@ -259,10 +320,26 @@
       document.getElementById('avisoLegal').textContent = t.avisoLegal;
       document.getElementById('linkReadme').textContent = t.linkReadme;
       document.getElementById('marcaRegistrada').textContent = t.marcaRegistrada;
-      
+
+      const kofiTextElem = document.getElementById('kofiText');
+      if (kofiTextElem) {
+        kofiTextElem.textContent = t.kofiText;
+      }
+
+      const kofiButton = document.getElementById('kofiButton');
+      if (kofiButton) {
+        kofiButton.setAttribute('aria-label', t.kofiAriaLabel);
+        kofiButton.setAttribute('title', t.kofiAriaLabel);
+      }
+
+      const kofiImage = document.getElementById('kofiImage');
+      if (kofiImage) {
+        kofiImage.setAttribute('alt', t.kofiAlt);
+      }
+
       // Actualizar selector de idioma
       document.getElementById('selectorIdioma').value = idiomaActual;
-      
+
       // Actualizar títulos de sagas y libros
       actualizarLibrosYSagas();
     }


### PR DESCRIPTION
## Summary
- add a floating Ko-fi button that adapts to the selected language
- extend translation logic and accessibility metadata for the donation entry point
- document the optional Ko-fi support link in the README, términos y condiciones, and política de privacidad

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca2a5032e88331a81c9c4d32df5a59