### PR TITLE
Add Hoid's Travails entries and update book list to 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ Esta aplicación web permite a los lectores del Cosmere organizar visualmente to
 
 ## 📖 Libros incluidos
 
-La aplicación incluye todos los libros principales del Cosmere hasta 2024:
+La aplicación incluye los libros principales y obras destacadas del Cosmere publicados o anunciados hasta 2026:
 
 - **Elantris** (incluye "La esperanza de Elantris" y "El alma del emperador")
 - **Nacidos de la bruma** (Era 1 y 2, incluye "Historia secreta" y otros relatos)
 - **Archivo de las Tormentas** (incluye "Danzante del filo", "Esquirla del amanecer")
-- **Otros libros** (Warbreaker, White Sand, Tress, Yumi, El hombre iluminado, etc.)
+- **Las andanzas de Hoid** (Tress of the Emerald Sea, Yumi and the Nightmare Painter, The Fires of December)
+- **Otros libros y novelas independientes** (Warbreaker, White Sand, El hombre iluminado, Islas de la Ascuaoscura, etc.)
 
-**Total**: 28 libros organizados cronológicamente por orden de publicación recomendado.
+**Total**: 29 libros organizados cronológicamente por orden de publicación recomendado.
 
 ## ✨ Características Avanzadas
 

--- a/index.html
+++ b/index.html
@@ -265,11 +265,12 @@
         {"id": 21, "title": {"es": "Esquirla del amanecer", "en": "Dawnshard"}, "saga": {"es": "Archivo de las Tormentas", "en": "The Stormlight Archive"}, "is_secundario": true, "is_read": "unread"},
         {"id": 22, "title": {"es": "El ritmo de la guerra", "en": "Rhythm of War"}, "saga": {"es": "Archivo de las Tormentas", "en": "The Stormlight Archive"}, "is_secundario": false, "is_read": "unread"},
         {"id": 23, "title": {"es": "El metal perdido", "en": "The Lost Metal"}, "saga": {"es": "Nacidos de la bruma", "en": "Mistborn"}, "is_secundario": false, "is_read": "unread"},
-        {"id": 24, "title": {"es": "Trenza del mar Esmeralda", "en": "Tress of the Emerald Sea"}, "saga": {"es": "Otros", "en": "Others"}, "is_secundario": true, "is_read": "unread"},
-        {"id": 25, "title": {"es": "Yumi y el pintor de pesadillas", "en": "Yumi and the Nightmare Painter"}, "saga": {"es": "Otros", "en": "Others"}, "is_secundario": true, "is_read": "unread"},
+        {"id": 24, "title": {"es": "Trenza del mar Esmeralda", "en": "Tress of the Emerald Sea"}, "saga": {"es": "Las andanzas de Hoid", "en": "Hoid's Travails"}, "is_secundario": true, "is_read": "unread"},
+        {"id": 25, "title": {"es": "Yumi y el pintor de pesadillas", "en": "Yumi and the Nightmare Painter"}, "saga": {"es": "Las andanzas de Hoid", "en": "Hoid's Travails"}, "is_secundario": true, "is_read": "unread"},
         {"id": 26, "title": {"es": "El hombre iluminado", "en": "The Sunlit Man"}, "saga": {"es": "Otros", "en": "Others"}, "is_secundario": true, "is_read": "unread"},
         {"id": 27, "title": {"es": "Viento y verdad", "en": "Wind and Truth"}, "saga": {"es": "Archivo de las Tormentas", "en": "The Stormlight Archive"}, "is_secundario": false, "is_read": "unread"},
-        {"id": 28, "title": {"es": "Islas de la Ascuaoscura", "en": "Isles of the Emberdark"}, "saga": {"es": "Otros", "en": "Others"}, "is_secundario": true, "is_read": "unread"}
+        {"id": 28, "title": {"es": "Islas de la Ascuaoscura", "en": "Isles of the Emberdark"}, "saga": {"es": "Otros", "en": "Others"}, "is_secundario": true, "is_read": "unread"},
+        {"id": 29, "title": {"es": "The Fires of December", "en": "The Fires of December"}, "saga": {"es": "Las andanzas de Hoid", "en": "Hoid's Travails"}, "is_secundario": true, "is_read": "unread"}
       ]
     };
 


### PR DESCRIPTION
### Motivation
- Bring the app's book list up to date with works published or announced through 2026 and include Hoid-centric short works.
- Correct saga classification for a couple of entries and update the displayed total count to reflect the added book.

### Description
- Updated `README.md` to state coverage through 2026, add the "Las andanzas de Hoid" section, and increment the total from `28` to `29`.
- Modified `index.html` `datos.libros` array to change the `saga` for IDs `24` and `25` to "Las andanzas de Hoid"/`Hoid's Travails`, and added a new entry ID `29` for `The Fires of December` under that saga.
- Performed minor formatting/ordering adjustments in the `datos.libros` JSON to keep entries consistent.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26ed5ae91c83318d24b379e2424b51)